### PR TITLE
Properly handle array outputs

### DIFF
--- a/.changeset/angry-radios-rule.md
+++ b/.changeset/angry-radios-rule.md
@@ -1,0 +1,5 @@
+---
+"sveltekit-api": patch
+---
+
+Return arrays as JSON arrays instead of objects with the indices as keys

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -586,15 +586,15 @@ export class API {
 		module: object,
 		fallback?: Record<never, never>,
 	): Promise<Record<string, unknown>> {
-		const output: Record<string, unknown> = {
-			...fallback,
-			...(typeof out === "object" ? out : undefined),
-		};
+		const output: Record<string, unknown> | unknown[] = Array.isArray(out)
+			? out
+			: {
+					...fallback,
+					...(typeof out === "object" ? out : undefined),
+				};
 
 		const validator =
-			"Output" in module && module.Output instanceof z.ZodObject
-				? module.Output
-				: z.object({});
+			"Output" in module && module.Output instanceof z.ZodType ? module.Output : z.object({});
 		const validation = await validator.spa(output);
 		if (!validation.success) {
 			log.extend("error")("output: %O failed validation: %O", output, validation.error);


### PR DESCRIPTION
Currently arrays are transformed in objects with the array indices as (string) keys through the spread operator.

With this pull request arrays are properly returned as arrays, and additionally the validation now properly works for non object ZodTypes.