### PR TITLE
fix: parse_module cannot parse routes with more than one params

### DIFF
--- a/.changeset/friendly-months-approve.md
+++ b/.changeset/friendly-months-approve.md
@@ -1,0 +1,5 @@
+---
+"sveltekit-api": patch
+---
+
+fix: parse_module cannot parse routes with more than one params

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -629,7 +629,7 @@ export class API {
 			.slice(0, -1)
 			.join("/")
 			.replace(/^\./, this.base)
-			.replace(/\[(?:\.{3})?(.+)\]/g, "{$1}");
+			.replace(/\[(\.{3})?(.+?)\]/g, "{$2}");
 		const method = parts[parts.length - 1].toUpperCase();
 
 		let module = (await handler()) as APIRoute;


### PR DESCRIPTION
fixes #52 