### PR TITLE
fix: group routes

### DIFF
--- a/.changeset/quiet-coins-sort.md
+++ b/.changeset/quiet-coins-sort.md
@@ -1,0 +1,5 @@
+---
+"sveltekit-api": patch
+---
+
+handle group routes

--- a/src/api/group/GET.ts
+++ b/src/api/group/GET.ts
@@ -1,0 +1,5 @@
+import { json } from "@sveltejs/kit";
+
+export default function () {
+	return json({ status: "ok" });
+}

--- a/src/api/group/[param]/GET.ts
+++ b/src/api/group/[param]/GET.ts
@@ -1,0 +1,9 @@
+import { Endpoint } from "$lib/api.js";
+import { z } from "$lib/index.js";
+import { json } from "@sveltejs/kit";
+
+export const Param = z.object({ param: z.string() });
+
+export default new Endpoint({ Param }).handle(async (params) => {
+	return json(params);
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -213,7 +213,7 @@ export class API {
 
 		const route =
 			this.routes[
-				`${evt.route.id.replace(this.base, ".")}/${evt.request.method.toUpperCase()}`
+				`${evt.route.id.replace(/\(.+\)\//g, "").replace(this.base, ".")}/${evt.request.method.toUpperCase()}`
 			];
 		if (!route) {
 			throw error(404, "Route not found");
@@ -637,7 +637,8 @@ export class API {
 			.slice(0, -1)
 			.join("/")
 			.replace(/^\./, this.base)
-			.replace(/\[(\.{3})?(.+?)\]/g, "{$2}");
+			.replace(/\[(\.{3})?(.+?)\]/g, "{$2}")
+			.replace(/\(.+\)\//g, "");
 		const method = parts[parts.length - 1].toUpperCase();
 
 		let module = (await handler()) as APIRoute;

--- a/src/routes/(group)/api/group/+server.ts
+++ b/src/routes/(group)/api/group/+server.ts
@@ -1,0 +1,3 @@
+import api from "$api/index.js";
+
+export const GET = (evt) => api.handle(evt);

--- a/src/routes/(group)/api/group/[param]/+server.ts
+++ b/src/routes/(group)/api/group/[param]/+server.ts
@@ -1,0 +1,3 @@
+import api from "$api/index.js";
+
+export const GET = (evt) => api.handle(evt);


### PR DESCRIPTION
This PR will fix routes that prefixes groups

for example:
```
routes/
├─ (group)/
├── api/
├─── endpoint/
├──── +server.ts
```